### PR TITLE
fix: replace bare except clauses with except Exception

### DIFF
--- a/benchmarks/benchmark/base_generator.py
+++ b/benchmarks/benchmark/base_generator.py
@@ -666,7 +666,7 @@ class RayMixin:
                     "  ✓ Ray connected to existing cluster (auto-detected)",
                     style=success_style,
                 )
-            except:
+            except Exception:
                 # Fallback to local mode
                 console.print(
                     "  [yellow]No existing cluster found, initializing local mode...[/yellow]",

--- a/benchmarks/benchmark/tasks/v1_0/base_loader.py
+++ b/benchmarks/benchmark/tasks/v1_0/base_loader.py
@@ -292,7 +292,7 @@ class BaseLoader(ABC):
             if isinstance(messages, str):
                 try:
                     messages = json.loads(messages)
-                except:
+                except Exception:
                     console.print(f"Sample {sample_id}: failed to parse messages, skipping")
                     continue
 
@@ -317,7 +317,7 @@ class BaseLoader(ABC):
             if isinstance(metadata_raw, str):
                 try:
                     metadata_dict = json.loads(metadata_raw)
-                except:
+                except Exception:
                     console.print(f"Sample {sample_id}: failed to parse metadata, skipping")
                     continue
             elif isinstance(metadata_raw, dict):

--- a/pretrain/onerec_llm/data/qwen3_dataset.py
+++ b/pretrain/onerec_llm/data/qwen3_dataset.py
@@ -46,7 +46,7 @@ class Qwen3ChatCompletionDataset(IterableDataset):
 
         try:
             model_config = AutoConfig.from_pretrained(self.kwargs.base_model_dir)
-        except:
+        except Exception:
             model_config = Qwen3Config.from_pretrained(self.kwargs.base_model_dir)
 
         self.pad_token_id = model_config.pad_token_id
@@ -477,14 +477,14 @@ class Qwen3ChatCompletionDataset(IterableDataset):
 
                 try:
                     source_name = sample["json"]["source"]
-                except:
+                except Exception:
                     source_name = "None"
 
                 self.source_sample_cnt.setdefault(source_name, 0)
                 self.source_sample_cnt[source_name] += 1
             
                 inputs = self._process(sample, source_name)
-            except:
+            except Exception:
                 self.source_error_cnt.setdefault(source_name, 0)
                 self.source_error_cnt[source_name] += 1
                 error_ratio = self.source_error_cnt[source_name] * 1.0 / \

--- a/pretrain/onerec_llm/utils/common.py
+++ b/pretrain/onerec_llm/utils/common.py
@@ -20,7 +20,7 @@ from transformers import set_seed as set_transformers_seed
 def print_rank_n(*msg, rank=0):
     try:
         _rank = dist.get_rank()
-    except:
+    except Exception:
         _rank = 0
     if _rank == rank:
         print(*msg)

--- a/pretrain/onerec_llm/utils/data_utils.py
+++ b/pretrain/onerec_llm/utils/data_utils.py
@@ -154,7 +154,7 @@ def _load_parquet_from_hdfs(
             print(f"Warning: Cached file {cache_path} is corrupted, removing: {e}")
             try:
                 os.remove(cache_path)
-            except:
+            except Exception:
                 pass
     
     # Download from HDFS with retry

--- a/verl_rl/recipe/entropy/reward_score/entropy_math/math_normalize.py
+++ b/verl_rl/recipe/entropy/reward_score/entropy_math/math_normalize.py
@@ -51,7 +51,7 @@ def normalize_answer(answer: Optional[str]) -> Optional[str]:
         if m is not None:
             answer = m.group("text").strip()
         return _strip_string(answer)
-    except:  # noqa: E722
+    except Exception:  # noqa: E722
         return answer
 
 
@@ -67,7 +67,7 @@ def _fix_fracs(string):
             else:
                 try:
                     assert len(substr) >= 2
-                except:  # noqa: E722
+                except Exception:  # noqa: E722
                     return string
                 a = substr[0]
                 b = substr[1]
@@ -98,7 +98,7 @@ def _fix_a_slash_b(string):
         assert string == "{}/{}".format(a, b)
         new_string = "\\frac{" + str(a) + "}{" + str(b) + "}"
         return new_string
-    except:  # noqa: E722
+    except Exception:  # noqa: E722
         return string
 
 

--- a/verl_rl/tests/workers/rollout/test_custom_completion_callback.py
+++ b/verl_rl/tests/workers/rollout/test_custom_completion_callback.py
@@ -87,7 +87,7 @@ class Sandbox:
         finally:
             try:
                 os.unlink(temp_file)
-            except:  # noqa: E722
+            except Exception:  # noqa: E722
                 pass
 
     async def _start_fastapi_server(self):

--- a/verl_rl/verl/utils/reward_score/math.py
+++ b/verl_rl/verl/utils/reward_score/math.py
@@ -99,7 +99,7 @@ def fix_fracs(string):
             else:
                 try:
                     assert len(substr) >= 2
-                except:  # noqa: E722
+                except Exception:  # noqa: E722
                     return string
                 a = substr[0]
                 b = substr[1]
@@ -130,7 +130,7 @@ def fix_a_slash_b(string):
         assert string == "{}/{}".format(a, b)
         new_string = "\\frac{" + str(a) + "}{" + str(b) + "}"
         return new_string
-    except:  # noqa: E722
+    except Exception:  # noqa: E722
         return string
 
 

--- a/verl_rl/verl/utils/reward_score/prime_math/math_normalize.py
+++ b/verl_rl/verl/utils/reward_score/prime_math/math_normalize.py
@@ -51,7 +51,7 @@ def normalize_answer(answer: Optional[str]) -> Optional[str]:
         if m is not None:
             answer = m.group("text").strip()
         return _strip_string(answer)
-    except:  # noqa: E722
+    except Exception:  # noqa: E722
         return answer
 
 
@@ -67,7 +67,7 @@ def _fix_fracs(string):
             else:
                 try:
                     assert len(substr) >= 2
-                except:  # noqa: E722
+                except Exception:  # noqa: E722
                     return string
                 a = substr[0]
                 b = substr[1]
@@ -98,7 +98,7 @@ def _fix_a_slash_b(string):
         assert string == "{}/{}".format(a, b)
         new_string = "\\frac{" + str(a) + "}{" + str(b) + "}"
         return new_string
-    except:  # noqa: E722
+    except Exception:  # noqa: E722
         return string
 
 


### PR DESCRIPTION
Replace 17 bare `except:` clauses across 9 files with `except Exception:`. Bare except catches `BaseException` including `SystemExit`/`KeyboardInterrupt`, preventing clean shutdown during training and evaluation.